### PR TITLE
Add automatic trailing whitespaces removal on save

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -16,3 +16,6 @@ let g:indentLine_char = '.'
 set nu
 call vundle#end()            " required
 filetype plugin indent on    " required
+
+" Remove trailing whitespaces on :w
+autocmd BufWritePre * %s/\s\+$//e


### PR DESCRIPTION
It removes all trailing whitespaces from all files (if you want to remove from certain types, then you need "*" replace with e.g. "cpp"